### PR TITLE
Fixed texture dump errors

### DIFF
--- a/Core_OverlayMods/Clothes/KoiClothesOverlayController.cs
+++ b/Core_OverlayMods/Clothes/KoiClothesOverlayController.cs
@@ -609,6 +609,7 @@ namespace KoiClothesOverlayX
                 if (texture == null)
                     throw new Exception("There are no renderers or textures to dump");
 
+                // Fix being unable to save some texture formats with EncodeToPNG
                 var tex = texture.ToTexture2D();
                 var png = tex.EncodeToPNG();
                 Destroy(tex);

--- a/Core_OverlayMods/Clothes/KoiClothesOverlayController.cs
+++ b/Core_OverlayMods/Clothes/KoiClothesOverlayController.cs
@@ -604,18 +604,13 @@ namespace KoiClothesOverlayX
             try
             {
                 var renderer = GetApplicableRenderers(rendererArrs).FirstOrDefault();
-                var renderTexture = (RenderTexture)renderer?.material?.mainTexture;
+                var texture = renderer?.material?.mainTexture;
 
-                if (renderTexture == null)
+                if (texture == null)
                     throw new Exception("There are no renderers or textures to dump");
 
-                RenderTexture.active = renderTexture;
-
-                var tex = new Texture2D(renderTexture.width, renderTexture.height, TextureFormat.ARGB32, false);
-                tex.ReadPixels(new Rect(0, 0, renderTexture.width, renderTexture.height), 0, 0);
-
+                var tex = texture.ToTexture2D();
                 var png = tex.EncodeToPNG();
-
                 Destroy(tex);
 
                 _dumpCallback(png);


### PR DESCRIPTION
Fixed dump failure for some textures.
If it looks good, please merge.

![スクリーンショット 2024-01-26 031940](https://github.com/ManlyMarco/Illusion-Overlay-Mods/assets/4230203/b0400c02-1f6e-4f07-91af-499c7adda6ce)

Card:
![Koikatu_F_20240126015529888_春野 千佳](https://github.com/ManlyMarco/Illusion-Overlay-Mods/assets/4230203/9299cb09-7af9-40aa-9387-99c84438ba2d)
