### PR TITLE
Summarize the call to RefreshAllTexturesCo()

### DIFF
--- a/Core_OverlayMods/Clothes/KoiClothesOverlayController.cs
+++ b/Core_OverlayMods/Clothes/KoiClothesOverlayController.cs
@@ -37,6 +37,7 @@ namespace KoiClothesOverlayX
 
         private Action<byte[]> _dumpCallback;
         private string _dumpClothesId;
+        private int _delayRefreshAllTexturesCo = 0; //Number of frames to delay RefreshAllTextures calls from coroutines.
 
 #if !EC
         public bool EnableInStudio { get; set; } = true;
@@ -419,7 +420,7 @@ namespace KoiClothesOverlayX
                 _allOverlayTextures = new Dictionary<CoordinateType, Dictionary<string, ClothesTexData>>();
 
             if (anyPrevious || _allOverlayTextures.Any())
-                StartCoroutine(RefreshAllTexturesCo());
+                KickRefreshAllTexturesCo();
         }
 
         private static void SetOverlayExtData(Dictionary<CoordinateType, Dictionary<string, ClothesTexData>> allOverlayTextures, PluginData data)
@@ -495,12 +496,22 @@ namespace KoiClothesOverlayX
                 }
             }
 
-            StartCoroutine(RefreshAllTexturesCo());
+            KickRefreshAllTexturesCo();
+        }
+
+        private void KickRefreshAllTexturesCo()
+        {
+            //If it is being delayed, the call will not be made.
+            if (_delayRefreshAllTexturesCo <= 0)
+                StartCoroutine(RefreshAllTexturesCo());
+
+            _delayRefreshAllTexturesCo = 3;
         }
 
         private IEnumerator RefreshAllTexturesCo()
         {
-            yield return null;
+            while( --_delayRefreshAllTexturesCo > 0 )
+                yield return null;
             RefreshAllTextures();
         }
 


### PR DESCRIPTION
KickRefreshAllTexturesCo() was sometimes called multiple times within a few frames for the same character during scene loading.
Added a delay frame and modified it so that it is called only once if another call comes in during that time.
Please merge if you don't mind.

When tested on a scene with 10 characters with and 10 without overlays, loading time was reduced by 4 seconds.

before average:43.18[s]
```
Scene loading completed: 43.9[s]
Scene loading completed: 43.3[s]
Scene loading completed: 42.8[s]
Scene loading completed: 42.4[s]
Scene loading completed: 43.5[s]
```

after average:38.86[s]  -4.32[s]
```
Scene loading completed: 40.8[s]
Scene loading completed: 38.4[s]
Scene loading completed: 38.4[s]
Scene loading completed: 38.1[s]
Scene loading completed: 38.6[s]
```

The overlay was not directly heavy, but SetCoordinateInfo() was inducing a large amount of resource reloading internally, which was heavy.
For example, reloading asset bundles as shown below.
```
  at UnityEngine.AssetBundle.DMD<UnityEngine.AssetBundle::LoadAsset> (UnityEngine.AssetBundle , System.String , System.Type ) [0x00000] in <6ecf63bad40043cabba2a3f491a0e3df>:0 
  at AssetBundleManager.DMD<AssetBundleManager::LoadAsset> (System.String , System.String , System.Type , System.String ) [0x00000] in <8b09ac0ba803494aafbed35d2609270f>:0 
  at CommonLib.LoadAsset[T] (System.String assetBundleName, System.String assetName, System.Boolean clone, System.String manifestName, System.Boolean check) [0x00000] in <8b09ac0ba803494aafbed35d2609270f>:0 
  at ChaControl.DMD<ChaControl::LoadCharaFbxDataNoAsync> (ChaControl , System.Action`1[T] , System.Action`1[T] , System.Boolean , System.Int32 , System.Int32 , System.String , System.Boolean , System.Byte , UnityEngine.Transform , System.Int32 , System.Boolean ) [0x00000] in <8b09ac0ba803494aafbed35d2609270f>:0 
  at ChaControl.LoadCharaFbxData (System.Action`1[T] actListInfo, System.Boolean _hiPoly, System.Int32 category, System.Int32 id, System.String createName, System.Boolean copyDynamicBone, System.Byte copyWeights, UnityEngine.Transform trfParent, System.Int32 defaultId, System.Boolean worldPositionStays) [0x00000] in <8b09ac0ba803494aafbed35d2609270f>:0 
  at ChaControl.DMD<ChaControl::ChangeClothesShoesNoAsync> (ChaControl , System.Int32 , System.Int32 , System.Boolean ) [0x00000] in <8b09ac0ba803494aafbed35d2609270f>:0 
  at ChaControl.ChangeClothesShoes (System.Int32 type, System.Int32 id, System.Boolean forceChange) [0x00000] in <8b09ac0ba803494aafbed35d2609270f>:0 
  at ChaControl.DMD<ChaControl::ChangeClothesNoAsync> (ChaControl , System.Int32 , System.Int32 , System.Int32 , System.Int32 , System.Int32 , System.Boolean , System.Boolean ) [0x00000] in <8b09ac0ba803494aafbed35d2609270f>:0 
  at ChaControl.ChangeClothes (System.Boolean forceChange, System.Boolean update) [0x00000] in <8b09ac0ba803494aafbed35d2609270f>:0 
  at ChaControl.DMD<ChaControl::ReloadNoAsync> (ChaControl , System.Boolean , System.Boolean , System.Boolean , System.Boolean ) [0x00000] in <8b09ac0ba803494aafbed35d2609270f>:0 
  at ChaControl.DMD<ChaControl::Reload> (ChaControl , System.Boolean , System.Boolean , System.Boolean , System.Boolean ) [0x00000] in <8b09ac0ba803494aafbed35d2609270f>:0 
  at Studio.OCIChar.DMD<Studio.OCIChar::SetCoordinateInfo> (Studio.OCIChar , ChaFileDefine+CoordinateType , System.Boolean ) [0x00000] in <8b09ac0ba803494aafbed35d2609270f>:0 
  at Studio.OCICharMale.DMD<Studio.OCICharMale::SetCoordinateInfo> (Studio.OCICharMale , ChaFileDefine+CoordinateType , System.Boolean ) [0x00000] in <8b09ac0ba803494aafbed35d2609270f>:0 
  at KoiClothesOverlayX.KoiClothesOverlayController.RefreshAllTextures (System.Boolean onlyMasks) [0x00000] in <f0838d021e6c49bca8136074b7490f8e>:0 
  at KoiClothesOverlayX.KoiClothesOverlayController.RefreshAllTextures () [0x00000] in <f0838d021e6c49bca8136074b7490f8e>:0 
  at KoiClothesOverlayX.KoiClothesOverlayController+<RefreshAllTexturesCo>d__30.MoveNext () [0x00000] in <f0838d021e6c49bca8136074b7490f8e>:0 
```