### PR TITLE
Fixed a bug that caused incomplete character changes

### DIFF
--- a/Core_OverlayMods/Clothes/KoiClothesOverlayController.cs
+++ b/Core_OverlayMods/Clothes/KoiClothesOverlayController.cs
@@ -510,7 +510,8 @@ namespace KoiClothesOverlayX
 
         private IEnumerator RefreshAllTexturesCo()
         {
-            while( --_delayRefreshAllTexturesCo > 0 )
+            yield return null;
+            while ( --_delayRefreshAllTexturesCo > 0 )
                 yield return null;
             RefreshAllTextures();
         }


### PR DESCRIPTION
#27 
There seems to be a code somewhere that assumes that the character is changed after more than one frame has elapsed.
The bug was avoided by re-adding the previously existing 'yield return'.
Please review and merge.

Checked in KK and KKS, problem occurred only in KK.
The problem was caused by change #26.
If this causes more problems, it may be better to limit the delay to loading time.

How to reproduce
1. Load a scene. Chica with large breasts is placed in the scene.
2. Select a character and change to a chica with smaller breasts.
Chica breast size will not be changed.

![Koikatu_F_20240610082453049_春野 千佳](https://github.com/ManlyMarco/Illusion-Overlay-Mods/assets/4230203/63f5d7c5-b4eb-4143-ad30-3f7e1e45a590)
![2024_0610_0826_25_375](https://github.com/ManlyMarco/Illusion-Overlay-Mods/assets/4230203/97da2171-2131-434f-8b56-26bf38b9cf15)

![Koikatu_F_20240610082333136_春野 千佳](https://github.com/ManlyMarco/Illusion-Overlay-Mods/assets/4230203/37c7d7c6-902b-497f-b437-5ea05fa28b95)