### PR TITLE
[AI/HS2] Update OverlayBlit to apply the overlay only to the Albedo texture

### DIFF
--- a/Shared_AIHS2/Skin/Hooks.cs
+++ b/Shared_AIHS2/Skin/Hooks.cs
@@ -40,8 +40,8 @@ namespace KoiSkinOverlayX
             var controller = instance.trfParent?.GetComponent<KoiSkinOverlayController>();
             if (controller != null)
             {
-				// The albedo CustomTextureCreate will always be the first element in a CustomTextureControl's createCustomTex array
-				if (controller.ChaControl.customTexCtrlFace?.createCustomTex[0] == instance)
+                    // The albedo CustomTextureCreate will always be the first element in a CustomTextureControl's createCustomTex array
+                    if (controller.ChaControl.customTexCtrlFace?.createCustomTex[0] == instance)
                 {
                     OverlayBlitImpl(source, dest, mat, pass, controller, TexType.FaceUnder, TexType.FaceOver);
                     return;

--- a/Shared_AIHS2/Skin/Hooks.cs
+++ b/Shared_AIHS2/Skin/Hooks.cs
@@ -40,12 +40,12 @@ namespace KoiSkinOverlayX
             var controller = instance.trfParent?.GetComponent<KoiSkinOverlayController>();
             if (controller != null)
             {
-                if (controller.ChaControl.customTexCtrlFace?.createCustomTex?.Contains(instance) == true)
+                if (controller.ChaControl.customTexCtrlFace?.createCustomTex?.FirstorDefault() == instance)
                 {
                     OverlayBlitImpl(source, dest, mat, pass, controller, TexType.FaceUnder, TexType.FaceOver);
                     return;
                 }
-                if (controller.ChaControl.customTexCtrlBody?.createCustomTex?.Contains(instance) == true)
+                if (controller.ChaControl.customTexCtrlBody?.createCustomTex?.FirstorDefault() == instance)
                 {
                     OverlayBlitImpl(source, dest, mat, pass, controller, TexType.BodyUnder, TexType.BodyOver);
                     return;

--- a/Shared_AIHS2/Skin/Hooks.cs
+++ b/Shared_AIHS2/Skin/Hooks.cs
@@ -40,12 +40,13 @@ namespace KoiSkinOverlayX
             var controller = instance.trfParent?.GetComponent<KoiSkinOverlayController>();
             if (controller != null)
             {
-                if (controller.ChaControl.customTexCtrlFace?.createCustomTex?.FirstorDefault() == instance)
+				// The albedo CustomTextureCreate will always be the first element in a CustomTextureControl's createCustomTex array
+				if (controller.ChaControl.customTexCtrlFace?.createCustomTex[0] == instance)
                 {
                     OverlayBlitImpl(source, dest, mat, pass, controller, TexType.FaceUnder, TexType.FaceOver);
                     return;
                 }
-                if (controller.ChaControl.customTexCtrlBody?.createCustomTex?.FirstorDefault() == instance)
+                if (controller.ChaControl.customTexCtrlBody?.createCustomTex[0] == instance)
                 {
                     OverlayBlitImpl(source, dest, mat, pass, controller, TexType.BodyUnder, TexType.BodyOver);
                     return;

--- a/Shared_AIHS2/Skin/Hooks.cs
+++ b/Shared_AIHS2/Skin/Hooks.cs
@@ -40,8 +40,8 @@ namespace KoiSkinOverlayX
             var controller = instance.trfParent?.GetComponent<KoiSkinOverlayController>();
             if (controller != null)
             {
-                    // The albedo CustomTextureCreate will always be the first element in a CustomTextureControl's createCustomTex array
-                    if (controller.ChaControl.customTexCtrlFace?.createCustomTex[0] == instance)
+                // The albedo CustomTextureCreate will always be the first element in a CustomTextureControl's createCustomTex array
+                if (controller.ChaControl.customTexCtrlFace?.createCustomTex[0] == instance)
                 {
                     OverlayBlitImpl(source, dest, mat, pass, controller, TexType.FaceUnder, TexType.FaceOver);
                     return;


### PR DESCRIPTION
The `createCustomTex` texture array consists of one Albedo texture ("create_skin_body") and one Metallic+Gloss texture ("create_skin detail_body", which uses the red and blue channels), in this order. This change ensures that the overlay texture is applied only to the Albedo texture, instead of both. This addresses a scenario in which skin overlay textures appear shinier than expected in areas where colors have any blue and/or red values.
![image](https://github.com/user-attachments/assets/7d76d866-93c1-4be6-bd2b-f9f7c3226374)
![image](https://github.com/user-attachments/assets/e57e4c59-805a-499f-9f67-4e91400315c7)
