### PR TITLE
Resize clothing textures with a dropdown or when the overlay is larger than the original texture

### DIFF
--- a/Core_OverlayMods/Clothes/KoiClothesOverlayController.cs
+++ b/Core_OverlayMods/Clothes/KoiClothesOverlayController.cs
@@ -525,7 +525,15 @@ namespace KoiClothesOverlayX
                 {
                     if (isColormask)
                         ChaControl.InitBaseCustomTextureClothes(true, i);
-                    ChaControl.ChangeCustomClothes(true, i, true, true, true, true, true);
+                    ChaControl.ChangeCustomClothes(
+                        true,
+                        i,
+                        true,
+                        ChaControl.nowCoordinate.clothes.parts[i].colorInfo[0].pattern > 0,
+                        ChaControl.nowCoordinate.clothes.parts[i].colorInfo[1].pattern > 0,
+                        ChaControl.nowCoordinate.clothes.parts[i].colorInfo[2].pattern > 0,
+                        ChaControl.nowCoordinate.clothes.parts[i].colorInfo[3].pattern > 0
+                    );
                     return;
                 }
 
@@ -535,7 +543,15 @@ namespace KoiClothesOverlayX
                 i = Array.FindIndex(ChaControl.objParts, x => x != null && x.name == texType);
                 if (i >= 0)
                 {
-                    ChaControl.ChangeCustomClothes(false, i, true, true, true, true, true);
+                    ChaControl.ChangeCustomClothes(
+                        false,
+                        i,
+                        true,
+                        ChaControl.nowCoordinate.clothes.parts[i].colorInfo[0].pattern > 0,
+                        ChaControl.nowCoordinate.clothes.parts[i].colorInfo[1].pattern > 0,
+                        ChaControl.nowCoordinate.clothes.parts[i].colorInfo[2].pattern > 0,
+                        ChaControl.nowCoordinate.clothes.parts[i].colorInfo[3].pattern > 0
+                    );
                     return;
                 }
             }
@@ -562,7 +578,13 @@ namespace KoiClothesOverlayX
                 {
                     if (isColormask)
                         ChaControl.InitBaseCustomTextureClothes(i);
-                    ChaControl.ChangeCustomClothes(i, true, false, false, false);
+                    ChaControl.ChangeCustomClothes(
+                        i,
+                        true,
+                        ChaControl.nowCoordinate.clothes.parts[i].colorInfo[0].pattern > 0,
+                        ChaControl.nowCoordinate.clothes.parts[i].colorInfo[1].pattern > 0,
+                        ChaControl.nowCoordinate.clothes.parts[i].colorInfo[2].pattern > 0
+                    );
                     return;
                 }
             }

--- a/Core_OverlayMods/Clothes/KoiClothesOverlayController.cs
+++ b/Core_OverlayMods/Clothes/KoiClothesOverlayController.cs
@@ -45,7 +45,7 @@ namespace KoiClothesOverlayX
 #endif
 
         private Dictionary<CoordinateType, Dictionary<string, ClothesTexData>> _allOverlayTextures;
-        private Dictionary<string, ClothesTexData> CurrentOverlayTextures
+        internal Dictionary<string, ClothesTexData> CurrentOverlayTextures
         {
             get
             {
@@ -478,7 +478,7 @@ namespace KoiClothesOverlayX
                 {
                     if (isColormask)
                         ChaControl.InitBaseCustomTextureClothes(true, i);
-                    ChaControl.ChangeCustomClothes(true, i, true, false, false, false, false);
+                    ChaControl.ChangeCustomClothes(true, i, true, true, true, true, true);
                     return;
                 }
 
@@ -488,7 +488,7 @@ namespace KoiClothesOverlayX
                 i = Array.FindIndex(ChaControl.objParts, x => x != null && x.name == texType);
                 if (i >= 0)
                 {
-                    ChaControl.ChangeCustomClothes(false, i, true, false, false, false, false);
+                    ChaControl.ChangeCustomClothes(false, i, true, true, true, true, true);
                     return;
                 }
             }

--- a/Core_OverlayMods/Clothes/KoiClothesOverlayGui.cs
+++ b/Core_OverlayMods/Clothes/KoiClothesOverlayGui.cs
@@ -236,13 +236,13 @@ namespace KoiClothesOverlayX
             var resizeDropdown = e.AddControl(new MakerDropdown("Max Texture Size Override", new string[] { "original", "512", "1024", "2048", "4096", "8192" }, makerCategory, 0, owner));
             resizeDropdown.ValueChanged.Subscribe(_index =>
             {
-                KoiSkinOverlayMgr.Logger.LogInfo(_index);
                 var c = GetOverlayController();
                 if (c != null)
                 {
                     var newSize = _index == 0 ? 0 : (int)(Math.Pow(2f, _index - 1) * 512);
-                    var size = c.GetTextureSizeOverride(clothesId, newSize, true);
-                    if (size != newSize)
+                    var currentSize = c.GetTextureSizeOverride(clothesId, newSize, false);
+                    newSize = c.GetTextureSizeOverride(clothesId, newSize, true);
+                    if (newSize != currentSize)
                         c.RefreshTexture(KoiClothesOverlayController.MakeColormaskId(clothesId));
                 }
             });

--- a/Core_OverlayMods/Clothes/KoiClothesOverlayGui.cs
+++ b/Core_OverlayMods/Clothes/KoiClothesOverlayGui.cs
@@ -240,8 +240,8 @@ namespace KoiClothesOverlayX
                 if (c != null)
                 {
                     var newSize = _index == 0 ? 0 : (int)(Math.Pow(2f, _index - 1) * 512);
-                    var currentSize = c.GetTextureSizeOverride(clothesId, newSize, false);
-                    newSize = c.GetTextureSizeOverride(clothesId, newSize, true);
+                    var currentSize = c.GetTextureSizeOverride(clothesId);
+                    newSize = c.SetTextureSizeOverride(clothesId, newSize);
                     if (newSize != currentSize)
                         c.RefreshTexture(KoiClothesOverlayController.MakeColormaskId(clothesId));
                 }
@@ -258,7 +258,7 @@ namespace KoiClothesOverlayX
                     var renderer = ctrl?.GetApplicableRenderers(clothesId)?.FirstOrDefault();
                     var visible = renderer?.material?.mainTexture != null && KoiSkinOverlayMgr.SizeLimit.Value != KoiSkinOverlayMgr.TextureSizeLimit.Original;
 
-                    resizeDropdown.SetValue(Array.FindIndex(resizeDropdown.Options, x => x == ctrl.GetTextureSizeOverride(clothesId, 0, false).ToString()), false);
+                    resizeDropdown.SetValue(Array.FindIndex(resizeDropdown.Options, x => x == ctrl.GetTextureSizeOverride(clothesId).ToString()), false);
                     resizeDropdown.Visible.OnNext(visible);
                 }
             );

--- a/Shared_AIHS2/Clothes/KoiClothesOverlayController.Hooks.cs
+++ b/Shared_AIHS2/Clothes/KoiClothesOverlayController.Hooks.cs
@@ -101,7 +101,14 @@ namespace KoiClothesOverlayX
                 if (updated)
                 {
                     // Make sure any patterns are applied again
-                    __instance.ChangeCustomClothes(parts, true, true, true, true);
+                    if (__instance.nowCoordinate.clothes.parts[parts].colorInfo.Any(x => x.pattern > 0))
+                        __instance.ChangeCustomClothes(
+                            parts,
+                            false,
+                            __instance.nowCoordinate.clothes.parts[parts].colorInfo[0].pattern > 0,
+                            __instance.nowCoordinate.clothes.parts[parts].colorInfo[1].pattern > 0,
+                            __instance.nowCoordinate.clothes.parts[parts].colorInfo[2].pattern > 0
+                        );
                     // Since a custom color mask is now used, enable all color fields to actually make full use of it.
                     var clothesComponent = __instance.GetCustomClothesComponent(parts);
                     clothesComponent.useColorN01 = true;

--- a/Shared_AIHS2/Clothes/KoiClothesOverlayController.Hooks.cs
+++ b/Shared_AIHS2/Clothes/KoiClothesOverlayController.Hooks.cs
@@ -100,6 +100,8 @@ namespace KoiClothesOverlayX
 
                 if (updated)
                 {
+                    // Make sure any patterns are applied again
+                    __instance.ChangeCustomClothes(parts, true, true, true, true);
                     // Since a custom color mask is now used, enable all color fields to actually make full use of it.
                     var clothesComponent = __instance.GetCustomClothesComponent(parts);
                     clothesComponent.useColorN01 = true;

--- a/Shared_KKEC/Clothes/KoiClothesOverlayController.Hooks.cs
+++ b/Shared_KKEC/Clothes/KoiClothesOverlayController.Hooks.cs
@@ -250,7 +250,16 @@ namespace KoiClothesOverlayX
                 if (updated)
                 {
                     // Make sure any patterns are applied again
-                    __instance.ChangeCustomClothes(main, parts, true, true, true, true, true);
+                    if (__instance.nowCoordinate.clothes.parts[parts].colorInfo.Any(x => x.pattern > 0))
+                        __instance.ChangeCustomClothes(
+                                main,
+                                parts,
+                                false,
+                                __instance.nowCoordinate.clothes.parts[parts].colorInfo[0].pattern > 0,
+                                __instance.nowCoordinate.clothes.parts[parts].colorInfo[1].pattern > 0,
+                                __instance.nowCoordinate.clothes.parts[parts].colorInfo[2].pattern > 0,
+                                __instance.nowCoordinate.clothes.parts[parts].colorInfo[3].pattern > 0
+                            );
                     if (main)
                     {
                         // Since a custom color mask is now used, enable all color fields to actually make full use of it.

--- a/Shared_KKEC/Clothes/KoiClothesOverlayController.Hooks.cs
+++ b/Shared_KKEC/Clothes/KoiClothesOverlayController.Hooks.cs
@@ -249,6 +249,8 @@ namespace KoiClothesOverlayX
 
                 if (updated)
                 {
+                    // Make sure any patterns are applied again
+                    __instance.ChangeCustomClothes(main, parts, true, true, true, true, true);
                     if (main)
                     {
                         // Since a custom color mask is now used, enable all color fields to actually make full use of it.

--- a/Shared_KKEC/Skin/Hooks.cs
+++ b/Shared_KKEC/Skin/Hooks.cs
@@ -74,10 +74,7 @@ namespace KoiSkinOverlayX
                 }
             }
             var controllerClothes = instance.trfParent?.GetComponent<KoiClothesOverlayController>();
-            if (
-                controllerClothes != null
-                && KoiSkinOverlayMgr.SizeLimit.Value != KoiSkinOverlayMgr.TextureSizeLimit.Original
-            )
+            if (controllerClothes != null && KoiSkinOverlayMgr.SizeLimit.Value != KoiSkinOverlayMgr.TextureSizeLimit.Original)
             {
                 string clothesId = null;
 

--- a/Shared_KKEC/Skin/Hooks.cs
+++ b/Shared_KKEC/Skin/Hooks.cs
@@ -109,7 +109,7 @@ namespace KoiSkinOverlayX
         {
             var tex = controller.GetOverlayTex(clothesId, false);
             var texColor = controller.GetOverlayTex(KoiClothesOverlayController.MakeColormaskId(clothesId), false);
-            var newSize = controller.GetTextureSizeOverride(clothesId, 0, false);
+            var newSize = controller.GetTextureSizeOverride(clothesId);
 
             // Increase/decrease output texture size if needed to accomodate large overlays
             if (KoiSkinOverlayMgr.SizeLimit.Value != KoiSkinOverlayMgr.TextureSizeLimit.Original)


### PR DESCRIPTION
Just like with the body over/underlays, resize the texture of the clothing when the settings is enabled and the applied overlay/color mask is larger than the original.
This is also done when the color mask is larger because of patterns. 

Also fixed a small problem where patterns would disappear when changing color mask until you edited a pattern setting