### PR TITLE
Optimize loading overlays in studio

### DIFF
--- a/Core_OverlayMods/Clothes/KoiClothesOverlayController.cs
+++ b/Core_OverlayMods/Clothes/KoiClothesOverlayController.cs
@@ -524,13 +524,16 @@ namespace KoiClothesOverlayX
                 return;
             }
 
-            if (texType != null && !Util.InsideStudio())
+            if (texType != null)
             {
                 var i = Array.FindIndex(ChaControl.objClothes, x => x != null && x.name == texType);
                 if (i >= 0)
                 {
-                    if (isColormask)
+                    // Needed in studio to trigger anything at all
+                    // Needed for color masks to reinitialize them 
+                    if (Util.InsideStudio() || isColormask)
                         ChaControl.InitBaseCustomTextureClothes(true, i);
+
                     ChaControl.ChangeCustomClothes(
                         true,
                         i,
@@ -543,12 +546,12 @@ namespace KoiClothesOverlayX
                     return;
                 }
 
-                if (isColormask)
-                    for (i = 0; i < ChaControl.objParts.Length; i++)
-                        ChaControl.InitBaseCustomTextureClothes(false, i);
                 i = Array.FindIndex(ChaControl.objParts, x => x != null && x.name == texType);
                 if (i >= 0)
                 {
+                    if (Util.InsideStudio() || isColormask)
+                        ChaControl.InitBaseCustomTextureClothes(false, i);
+
                     ChaControl.ChangeCustomClothes(
                         false,
                         i,


### PR DESCRIPTION
Seems to work fine like this instead of forcing the character to load the current outfit again, despite the warning about the dynamic bones messing up.

I tested it myself on both KK and KKS, and a few others also tested it for me on either KK or KKS and it didn't break for anybody.

The aggressive refresh is still performed in studio when loading any type of mask.