### PR TITLE
[AI/HS2] Add DetailMainTex overlay support for face and body skin

### DIFF
--- a/Core_OverlayMods/Skin/KoiSkinOverlayController.cs
+++ b/Core_OverlayMods/Skin/KoiSkinOverlayController.cs
@@ -226,14 +226,18 @@ namespace KoiSkinOverlayX
 
         private bool IsShown(TexType overlayType)
         {
-#if !EC
+#if AI || HS2
             if (!KKAPI.Studio.StudioAPI.InsideStudio) return true;
-            return (EnableInStudioSkin && (overlayType <= TexType.FaceUnder || overlayType >= TexType.BodyOverGloss)) ||
+            return (EnableInStudioSkin && (overlayType <= TexType.FaceUnder || overlayType >= TexType.BodyDetailOver)) ||
                    (EnableInStudioIris && overlayType > TexType.FaceUnder && overlayType <= TexType.EyelineUnder);
+#elif !EC
+			if (!KKAPI.Studio.StudioAPI.InsideStudio) return true;
+			return EnableInStudioSkin && overlayType <= TexType.FaceUnder ||
+				   EnableInStudioIris && overlayType > TexType.FaceUnder;
 #else
             return true;
 #endif
-        }
+		}
 
         internal static void ApplyOverlays(RenderTexture targetTexture, IEnumerable<Texture2D> overlays)
         {
@@ -328,15 +332,15 @@ namespace KoiSkinOverlayX
             {
                 case TexType.BodyOver:
                 case TexType.BodyUnder:
-                case TexType.BodyOverGloss:
-                case TexType.BodyUnderGloss:
+                case TexType.BodyDetailOver:
+                case TexType.BodyDetailUnder:
                     cc.AddUpdateCMBodyTexFlags(true, true, true, true);
                     cc.CreateBodyTexture();
                     break;
                 case TexType.FaceOver:
                 case TexType.FaceUnder:
-                case TexType.FaceOverGloss:
-                case TexType.FaceUnderGloss:
+                case TexType.FaceDetailOver:
+                case TexType.FaceDetailUnder:
                     cc.AddUpdateCMFaceTexFlags(true, true, true, true, true, true, true);
                     cc.CreateFaceTexture();
                     break;

--- a/Core_OverlayMods/Skin/KoiSkinOverlayController.cs
+++ b/Core_OverlayMods/Skin/KoiSkinOverlayController.cs
@@ -228,8 +228,8 @@ namespace KoiSkinOverlayX
         {
 #if !EC
             if (!KKAPI.Studio.StudioAPI.InsideStudio) return true;
-            return EnableInStudioSkin && overlayType <= TexType.FaceUnder ||
-                   EnableInStudioIris && overlayType > TexType.FaceUnder;
+            return (EnableInStudioSkin && (overlayType <= TexType.FaceUnder || overlayType >= TexType.BodyOverGloss)) ||
+                   (EnableInStudioIris && overlayType > TexType.FaceUnder && overlayType <= TexType.EyelineUnder);
 #else
             return true;
 #endif
@@ -328,11 +328,15 @@ namespace KoiSkinOverlayX
             {
                 case TexType.BodyOver:
                 case TexType.BodyUnder:
+                case TexType.BodyOverGloss:
+                case TexType.BodyUnderGloss:
                     cc.AddUpdateCMBodyTexFlags(true, true, true, true);
                     cc.CreateBodyTexture();
                     break;
                 case TexType.FaceOver:
                 case TexType.FaceUnder:
+                case TexType.FaceOverGloss:
+                case TexType.FaceUnderGloss:
                     cc.AddUpdateCMFaceTexFlags(true, true, true, true, true, true, true);
                     cc.CreateFaceTexture();
                     break;

--- a/Core_OverlayMods/Skin/KoiSkinOverlayController.cs
+++ b/Core_OverlayMods/Skin/KoiSkinOverlayController.cs
@@ -231,13 +231,13 @@ namespace KoiSkinOverlayX
             return (EnableInStudioSkin && (overlayType <= TexType.FaceUnder || overlayType >= TexType.BodyDetailOver)) ||
                    (EnableInStudioIris && overlayType > TexType.FaceUnder && overlayType <= TexType.EyelineUnder);
 #elif !EC
-			if (!KKAPI.Studio.StudioAPI.InsideStudio) return true;
-			return EnableInStudioSkin && overlayType <= TexType.FaceUnder ||
-				   EnableInStudioIris && overlayType > TexType.FaceUnder;
+            if (!KKAPI.Studio.StudioAPI.InsideStudio) return true;
+            return EnableInStudioSkin && overlayType <= TexType.FaceUnder ||
+                   EnableInStudioIris && overlayType > TexType.FaceUnder;
 #else
             return true;
 #endif
-		}
+        }
 
         internal static void ApplyOverlays(RenderTexture targetTexture, IEnumerable<Texture2D> overlays)
         {

--- a/Core_OverlayMods/Skin/KoiSkinOverlayGui.cs
+++ b/Core_OverlayMods/Skin/KoiSkinOverlayGui.cs
@@ -175,8 +175,8 @@ namespace KoiSkinOverlayX
             SetupTexControls(e, makerCategory, owner, TexType.BodyUnder, "Body underlay texture (Under tattoos, blushes, etc.)");
 
 #if AI || HS2
-			// Controls for DetailMainTex
-			e.AddControl(new MakerSeparator(makerCategory, owner));
+            // Controls for DetailMainTex
+            e.AddControl(new MakerSeparator(makerCategory, owner));
 
             SetupTexControls(e, makerCategory, owner, TexType.FaceDetailOver, "Face detail overlay texture (On top of almost everything)");
 

--- a/Core_OverlayMods/Skin/KoiSkinOverlayGui.cs
+++ b/Core_OverlayMods/Skin/KoiSkinOverlayGui.cs
@@ -173,6 +173,23 @@ namespace KoiSkinOverlayX
             e.AddControl(new MakerSeparator(makerCategory, owner));
 
             SetupTexControls(e, makerCategory, owner, TexType.BodyUnder, "Body underlay texture (Under tattoos, blushes, etc.)");
+
+            e.AddControl(new MakerSeparator(makerCategory, owner));
+
+            // Metallic/gloss textures
+            SetupTexControls(e, makerCategory, owner, TexType.FaceOverGloss, "Face gloss overlay texture (On top of almost everything)");
+
+            e.AddControl(new MakerSeparator(makerCategory, owner));
+
+            SetupTexControls(e, makerCategory, owner, TexType.BodyOverGloss, "Body gloss overlay texture (On top of almost everything)");
+
+            e.AddControl(new MakerSeparator(makerCategory, owner));
+
+            SetupTexControls(e, makerCategory, owner, TexType.FaceUnderGloss, "Face gloss underlay texture (Under tattoos, blushes, etc.)");
+
+            e.AddControl(new MakerSeparator(makerCategory, owner));
+
+            SetupTexControls(e, makerCategory, owner, TexType.BodyUnderGloss, "Body gloss underlay texture (Under tattoos, blushes, etc.)");
         }
 
         private void SetupEyeInterface(RegisterSubCategoriesEvent e, KoiSkinOverlayMgr owner)

--- a/Core_OverlayMods/Skin/KoiSkinOverlayGui.cs
+++ b/Core_OverlayMods/Skin/KoiSkinOverlayGui.cs
@@ -174,22 +174,24 @@ namespace KoiSkinOverlayX
 
             SetupTexControls(e, makerCategory, owner, TexType.BodyUnder, "Body underlay texture (Under tattoos, blushes, etc.)");
 
-            e.AddControl(new MakerSeparator(makerCategory, owner));
+#if AI || HS2
+			// Controls for DetailMainTex
+			e.AddControl(new MakerSeparator(makerCategory, owner));
 
-            // Metallic/gloss textures
-            SetupTexControls(e, makerCategory, owner, TexType.FaceOverGloss, "Face gloss overlay texture (On top of almost everything)");
-
-            e.AddControl(new MakerSeparator(makerCategory, owner));
-
-            SetupTexControls(e, makerCategory, owner, TexType.BodyOverGloss, "Body gloss overlay texture (On top of almost everything)");
+            SetupTexControls(e, makerCategory, owner, TexType.FaceDetailOver, "Face detail overlay texture (On top of almost everything)");
 
             e.AddControl(new MakerSeparator(makerCategory, owner));
 
-            SetupTexControls(e, makerCategory, owner, TexType.FaceUnderGloss, "Face gloss underlay texture (Under tattoos, blushes, etc.)");
+            SetupTexControls(e, makerCategory, owner, TexType.BodyDetailOver, "Body detail overlay texture (On top of almost everything)");
 
             e.AddControl(new MakerSeparator(makerCategory, owner));
 
-            SetupTexControls(e, makerCategory, owner, TexType.BodyUnderGloss, "Body gloss underlay texture (Under tattoos, blushes, etc.)");
+            SetupTexControls(e, makerCategory, owner, TexType.FaceDetailUnder, "Face detail underlay texture (Under tattoos, blushes, etc.)");
+
+            e.AddControl(new MakerSeparator(makerCategory, owner));
+
+            SetupTexControls(e, makerCategory, owner, TexType.BodyDetailUnder, "Body detail underlay texture (Under tattoos, blushes, etc.)");
+#endif
         }
 
         private void SetupEyeInterface(RegisterSubCategoriesEvent e, KoiSkinOverlayMgr owner)

--- a/Core_OverlayMods/Skin/TexType.cs
+++ b/Core_OverlayMods/Skin/TexType.cs
@@ -30,5 +30,10 @@
         /// There's no up/down separation because it's effectively the same texture in KK. Also, there is no up/down separation in HS2 at all.
         /// </summary>
         EyelineUnder = 30,
-    }
+
+		BodyOverGloss = 41,
+		FaceOverGloss = 42,
+		BodyUnderGloss = 43,
+		FaceUnderGloss = 44,
+	}
 }

--- a/Core_OverlayMods/Skin/TexType.cs
+++ b/Core_OverlayMods/Skin/TexType.cs
@@ -31,24 +31,26 @@
         /// </summary>
         EyelineUnder = 30,
 
+#if AI || HS2
         /// <summary>
         /// Overlay for DetailMainTex (metallic/gloss) map; applies on top of tattoos
         /// </summary>
-        BodyOverGloss = 41,
+        BodyDetailOver = 41,
 
         /// <summary>
         /// Overlay for DetailMainTex (metallic/gloss) map; applies on top of tattoos, lips, eye shadow and blush
         /// </summary>
-        FaceOverGloss = 42,
+        FaceDetailOver = 42,
 
         /// <summary>
         /// Underlay for DetailMainTex (metallic/gloss) map; applies before tattoos
         /// </summary>
-        BodyUnderGloss = 43,
+        BodyDetailUnder = 43,
 
 		/// <summary>
 		/// Underlay for DetailMainTex (metallic/gloss) map; applies before tattoos, lips, eye shadow and blush
 		/// </summary>
-		FaceUnderGloss = 44,
+		FaceDetailUnder = 44,
+#endif
     }
 }

--- a/Core_OverlayMods/Skin/TexType.cs
+++ b/Core_OverlayMods/Skin/TexType.cs
@@ -47,10 +47,10 @@
         /// </summary>
         BodyDetailUnder = 43,
 
-		/// <summary>
-		/// Underlay for DetailMainTex (metallic/gloss) map; applies before tattoos, lips, eye shadow and blush
-		/// </summary>
-		FaceDetailUnder = 44,
+        /// <summary>
+        /// Underlay for DetailMainTex (metallic/gloss) map; applies before tattoos, lips, eye shadow and blush
+        /// </summary>
+        FaceDetailUnder = 44,
 #endif
     }
 }

--- a/Core_OverlayMods/Skin/TexType.cs
+++ b/Core_OverlayMods/Skin/TexType.cs
@@ -31,9 +31,24 @@
         /// </summary>
         EyelineUnder = 30,
 
-		BodyOverGloss = 41,
-		FaceOverGloss = 42,
-		BodyUnderGloss = 43,
+        /// <summary>
+        /// Overlay for DetailMainTex (metallic/gloss) map; applies on top of tattoos
+        /// </summary>
+        BodyOverGloss = 41,
+
+        /// <summary>
+        /// Overlay for DetailMainTex (metallic/gloss) map; applies on top of tattoos, lips, eye shadow and blush
+        /// </summary>
+        FaceOverGloss = 42,
+
+        /// <summary>
+        /// Underlay for DetailMainTex (metallic/gloss) map; applies before tattoos
+        /// </summary>
+        BodyUnderGloss = 43,
+
+		/// <summary>
+		/// Underlay for DetailMainTex (metallic/gloss) map; applies before tattoos, lips, eye shadow and blush
+		/// </summary>
 		FaceUnderGloss = 44,
-	}
+    }
 }

--- a/Core_OverlayMods/Skin/Util.cs
+++ b/Core_OverlayMods/Skin/Util.cs
@@ -103,10 +103,10 @@ namespace KoiSkinOverlayX
                 case TexType.BodyUnder:
                 case TexType.FaceOver:
                 case TexType.FaceUnder:
-                case TexType.BodyOverGloss:
-                case TexType.BodyUnderGloss:
-                case TexType.FaceOverGloss:
-                case TexType.FaceUnderGloss:
+                case TexType.BodyDetailOver:
+                case TexType.BodyDetailUnder:
+                case TexType.FaceDetailOver:
+                case TexType.FaceDetailUnder:
                     return new TexSize(4096);
                 case TexType.EyeUnder:
                 case TexType.EyeOver:

--- a/Core_OverlayMods/Skin/Util.cs
+++ b/Core_OverlayMods/Skin/Util.cs
@@ -103,6 +103,10 @@ namespace KoiSkinOverlayX
                 case TexType.BodyUnder:
                 case TexType.FaceOver:
                 case TexType.FaceUnder:
+                case TexType.BodyOverGloss:
+                case TexType.BodyUnderGloss:
+                case TexType.FaceOverGloss:
+                case TexType.FaceUnderGloss:
                     return new TexSize(4096);
                 case TexType.EyeUnder:
                 case TexType.EyeOver:

--- a/Shared_AIHS2/Skin/Hooks.cs
+++ b/Shared_AIHS2/Skin/Hooks.cs
@@ -55,12 +55,12 @@ namespace KoiSkinOverlayX
                 // The metallic/gloss CustomTextureCreate will always be the second element in a CustomTextureControl's createCustomTex array
                 if (controller.ChaControl.customTexCtrlFace?.createCustomTex[1] == instance)
                 {
-                    OverlayBlitImpl(source, dest, mat, pass, controller, TexType.FaceUnderGloss, TexType.FaceOverGloss);
+                    OverlayBlitImpl(source, dest, mat, pass, controller, TexType.FaceDetailUnder, TexType.FaceDetailOver);
                     return;
                 }
                 if (controller.ChaControl.customTexCtrlBody?.createCustomTex[1] == instance)
                 {
-                    OverlayBlitImpl(source, dest, mat, pass, controller, TexType.BodyUnderGloss, TexType.BodyOverGloss);
+                    OverlayBlitImpl(source, dest, mat, pass, controller, TexType.BodyDetailUnder, TexType.BodyDetailOver);
                     return;
                 }
             }

--- a/Shared_AIHS2/Skin/Hooks.cs
+++ b/Shared_AIHS2/Skin/Hooks.cs
@@ -51,6 +51,18 @@ namespace KoiSkinOverlayX
                     OverlayBlitImpl(source, dest, mat, pass, controller, TexType.BodyUnder, TexType.BodyOver);
                     return;
                 }
+
+                // The metallic/gloss CustomTextureCreate will always be the second element in a CustomTextureControl's createCustomTex array
+                if (controller.ChaControl.customTexCtrlFace?.createCustomTex[1] == instance)
+                {
+                    OverlayBlitImpl(source, dest, mat, pass, controller, TexType.FaceUnderGloss, TexType.FaceOverGloss);
+                    return;
+                }
+                if (controller.ChaControl.customTexCtrlBody?.createCustomTex[1] == instance)
+                {
+                    OverlayBlitImpl(source, dest, mat, pass, controller, TexType.BodyUnderGloss, TexType.BodyOverGloss);
+                    return;
+                }
             }
 
             // Fall back to original code


### PR DESCRIPTION
Requested by Hanmen
This feature adds support for overlays and underlays that apply specifically to the skin DetailMainTex texture - this is the metallic/gloss map for the skin (face and body). 4 new texture slots are added to the skin overlays menu:
- face detail overlay
- body detail overlay
- face detail underlay
- body detail underlay

Similarly to the main skin texture, the DetailMainTex texture is generated dynamically by the game, as it combines the corresponding metallic/gloss maps for things like tattoos, lips, eye shadow and blushes into one texture. Thus, compared to editing DetailMainTex in the Material Editor, this approach allows the user to blend custom maps with the game-generated texture, instead of always completely replacing it. The underlays get applied before the tattoos, lips, eye shadow and blushes are applied, while overlays apply on top of those. The alpha channel acts as a mask.

I wasn't able to find an equivalent in KK: in AI/HS2, DetailMainTex is always stored as the 2nd element in a CustomTextureCreate array (with albedo being the 1st), but for the other games there seems to be only one CustomTextureCreate (the albedo). So I limited the functionality and TexType values to AI/HS2.
![preview](https://github.com/user-attachments/assets/321f4cbe-11e9-40bb-871a-1913a33c84e4)
